### PR TITLE
Custom Redshift Logging Models + Dump to S3/Spectrum Tables

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -7,15 +7,6 @@ source-paths: ["models"]
 macro-paths: ["macros"]
 test-paths: ["tests"]
 
-archive:
-  - source_schema: dbt_dwall_redshift
-    target_schema: dbt_archive
-    tables:
-      - source_table: table_stats
-        target_table: table_stats_archived
-        updated_at: "getdate()"
-        unique_key: table_id
-
 models:
   redshift:
     schema: redshift

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -1,13 +1,27 @@
 name: 'redshift'
 version: '0.0.1'
 
+profile: 'default'
+
 source-paths: ["models"]
 macro-paths: ["macros"]
 test-paths: ["tests"]
 
+archive:
+  - source_schema: dbt_dwall_redshift
+    target_schema: dbt_archive
+    tables:
+      - source_table: table_stats
+        target_table: table_stats_archived
+        updated_at: "getdate()"
+        unique_key: table_id
+
 models:
   redshift:
     schema: redshift
+    vars:
+      iam_role: 'arn:aws:iam::842393318262:role/RedshiftCopyUnload'
+
     base:
       materialized: ephemeral
 
@@ -16,3 +30,17 @@ models:
 
     views:
       materialized: view
+      queries:
+        vars:
+          bucket_path: 's3://redshift-dbt-logs/query_logs/query_logs_'
+        post-hook: "unload ('select ql.* from dbt_spectrum_redshift.query_logs ql union select q.* from {{ this }} q where q.query_id not in (select ql.query_id from dbt_spectrum_redshift.query_logs ql)') to '{{ var('bucket_path') }}' iam_role '{{ var('iam_role') }}' manifest delimiter as ',' null as '' escape allowoverwrite"
+
+      query_text:
+        vars:
+          bucket_path: 's3://redshift-dbt-logs/query_text_logs/query_text_logs_'
+        post-hook: "unload ('select qtl.* from dbt_spectrum_redshift.query_text_logs qtl union select qt.* from {{ this }} qt where qt.query_id not in (select qtl.query_id from dbt_spectrum_redshift.query_text_logs qtl)') to '{{ var('bucket_path') }}' iam_role '{{ var('iam_role') }}' manifest delimiter as ',' null as '' escape allowoverwrite"
+
+      table_stats:
+        vars:
+          bucket_path: 's3://redshift-dbt-logs/table_stats_logs/table_stats_logs_'
+        post-hook: "unload ('select tsl.* from dbt_spectrum_redshift.table_stats_logs tsl union select ts.*, getdate() as snapshot_system_timestamp from {{ this }} ts') to '{{ var('bucket_path') }}' iam_role '{{ var('iam_role') }}' manifest delimiter as ',' null as '' escape allowoverwrite"

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -7,6 +7,7 @@ test-paths: ["tests"]
 
 models:
   redshift:
+    schema: redshift
     base:
       materialized: ephemeral
 

--- a/models/base/stl_querytext.sql
+++ b/models/base/stl_querytext.sql
@@ -1,0 +1,5 @@
+select
+  query as query_id,
+  sequence,
+  "text" as query_text
+from stl_querytext

--- a/models/base/stl_wlm_query.sql
+++ b/models/base/stl_wlm_query.sql
@@ -4,7 +4,7 @@ select
 , query as query_id
 , xid
 , task
-, service_class
+, service_class as service_class_id
 , slot_count
 , service_class_start_time
 , queue_start_time

--- a/models/base/stv_wlm_classification_config.sql
+++ b/models/base/stv_wlm_classification_config.sql
@@ -1,0 +1,10 @@
+select
+  id as service_class_id,
+  condition as query_conditions,
+  case
+    when id between 1 and 4 then 'Redshift Reserved Service Class'
+    when id = 5 then 'Redshift Superuser Query Queue'
+    when id > 5 then 'WLM Query Queue'
+    else null
+  end as service_class_type
+from stv_wlm_classification_config

--- a/models/base/stv_wlm_service_class_config.sql
+++ b/models/base/stv_wlm_service_class_config.sql
@@ -1,0 +1,13 @@
+select
+  service_class as service_class_id,
+  num_query_tasks as concurrency_allocation,
+  query_working_mem as memory_allocation,
+  name,
+  max_execution_time/1000.0 as max_execution_time_seconds,
+  case
+    when service_class between 1 and 4 then 'Redshift Reserved Service Class'
+    when service_class = 5 then 'Redshift Superuser Query Queue'
+    when service_class > 5 then 'WLM Query Queue'
+    else null
+  end as service_class_type
+from stv_wlm_service_class_config

--- a/models/base/svl_query_metrics_summary.sql
+++ b/models/base/svl_query_metrics_summary.sql
@@ -1,0 +1,19 @@
+select
+  userid as user_id,
+  query as query_id,
+  service_class as service_class_id,
+  query_cpu_time as query_cpu_time_seconds,
+  query_blocks_read,
+  query_execution_time as query_execution_time_seconds,
+  query_cpu_usage_percent,
+  query_temp_blocks_to_disk,
+  segment_execution_time as segment_execution_time_seconds,
+  cpu_skew,
+  io_skew,
+  scan_row_count,
+  join_row_count,
+  nested_loop_join_row_count,
+  return_row_count,
+  spectrum_scan_row_count,
+  spectrum_scan_size_mb
+from svl_query_metrics_summary

--- a/models/views/queries.sql
+++ b/models/views/queries.sql
@@ -1,50 +1,88 @@
 with queries as (
+select *
+from {{ref('stl_query')}}
+),
 
-  select * from {{ref('stl_query')}}
+users as (
+select *
+from {{ref('pg_user')}}
+),
 
-), users as (
+cost as (
+select *
+from {{ref('redshift_cost')}}
+),
 
-  select * from {{ref('pg_user')}}
+timings as (
+select *
+from {{ref('stl_wlm_query')}}
+),
 
-), cost as (
+service_class_classification as (
+select *
+from {{ ref('stv_wlm_classification_config') }}
+),
 
-  select * from {{ref('redshift_cost')}}
+service_class_config as (
+select *
+from {{ ref('stv_wlm_service_class_config') }}
+),
 
-), timings as (
-
-  select * from {{ref('stl_wlm_query')}}
-
+query_metrics as (
+select *
+from {{ ref('svl_query_metrics_summary') }}
 )
 
-
-
 select
+  queries.query_id,
+  queries.transaction_id,
+  users.username::varchar,
 
-  queries.query_id
-, queries.transaction_id
-, users.username::varchar
+  cost.starting_cost,
+  cost.total_cost,
 
-, cost.starting_cost
-, cost.total_cost
+  queries.aborted,
+  queries.started_at,
+  queries.finished_at,
 
-, queries.started_at
-, queries.finished_at
+  timings.queue_start_time,
+  timings.queue_end_time,
+  (timings.total_queue_time::float / 1000000.0) as total_queue_time_seconds,
 
-, timings.queue_start_time
-, timings.queue_end_time
-, (timings.total_queue_time::float / 1000000.0) as total_queue_time_seconds
+  timings.exec_start_time,
+  timings.exec_end_time,
+  (timings.total_exec_time::float / 1000000.0) as total_exec_time_seconds,
 
-, timings.exec_start_time
-, timings.exec_end_time
-, (timings.total_exec_time::float / 1000000.0) as total_exec_time_seconds
+  timings.service_class_id,
+  service_class_config.name as service_class_name,
+  service_class_config.service_class_type as wlm_service_class_type,
+  service_class_classification.query_conditions as wlm_service_class_query_conditions,
+  service_class_config.concurrency_allocation,
+  service_class_config.memory_allocation,
+  service_class_config.max_execution_time_seconds,
 
+  query_metrics.query_cpu_time_seconds,
+  query_metrics.query_blocks_read,
+  query_metrics.query_cpu_usage_percent,
+  query_metrics.query_temp_blocks_to_disk,
+  query_metrics.cpu_skew,
+  query_metrics.io_skew,
+  query_metrics.scan_row_count,
+  query_metrics.join_row_count,
+  query_metrics.nested_loop_join_row_count,
+  query_metrics.return_row_count,
+  query_metrics.spectrum_scan_row_count,
+  query_metrics.spectrum_scan_size_mb
 from queries
-
 left join users
-  on queries.user_id = users.user_id
-
+on queries.user_id = users.user_id
 left join cost
-  on queries.query_id = cost.query_id
-
+on queries.query_id = cost.query_id
 left join timings
-  on queries.query_id = timings.query_id
+on queries.query_id = timings.query_id
+left join service_class_classification
+on timings.service_class_id = service_class_classification.service_class_id
+left join service_class_config
+on timings.service_class_id = service_class_config.service_class_id
+left join query_metrics
+on queries.query_id = query_metrics.query_id

--- a/models/views/query_text.sql
+++ b/models/views/query_text.sql
@@ -1,0 +1,2 @@
+select *
+from {{ ref('stl_querytext') }}


### PR DESCRIPTION
This PR implements a few high-level changes to help with auditing and monitoring our Redshift cluster moving forward:

1. **Custom Schema** - The models in this package now write to a dedicated schema. The schema will change dynamically based on the user who is running the package, but it will ultimately take the form of the users target schema (e.g. `dbt_dwall`) and will be suffixed with `_redshift`. So in the case of me running a local dbt run to my development schema, the models would be consolidated under the schema `dbt_dwall_redshift`.
2. **Custom Models** - This PR builds off of the models that the Fishtown Analytics folks included in their Redshift dbt package and adds a few more fields that are relevant to us (e.g. information about the WLM service class a query was assigned to, query CPU allocation, etc.)
3. **`UNLOAD` to s3 + Spectrum tables** - One historical problem with investigating Redshift query performance is the fact that Redshift only stores ~5 days worth of historical data for query runs. This makes it very hard to get a good sense of how cluster performance has changed over time. In order to fix this, this PR implements a post-hook that dumps the new logging data into s3. Once unloaded, this new data will be immediately available to query using Redshift Spectrum (data will be located in the `dbt_spectrum_redshift` schema). Since the data being unloaded is virtual, as in not being physically located on disk, this means that we will be able to dump data directly so s3 without ever having to store intermediate data on disk. This also means that moving forward, we will have a complete historical view of query/cluster performance, without ever having to store this data on our Redshift cluster.
